### PR TITLE
Add versioning rules for AOSP submodule tags for Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,4 +26,20 @@
   "git-submodules": {
     enabled: true,
   },
+  packageRules: [
+    // https://github.com/renovatebot/renovate/discussions/43618#discussioncomment-17075386
+    {
+      description: 'Use regex versioning for AOSP submodule tags (android-<major>.<minor>.<patch>_r<build>)',
+      matchManagers: [
+        'git-submodules',
+      ],
+      matchDatasources: [
+        'git-refs',
+      ],
+      matchSourceUrls: [
+        'https://android.googlesource.com/**',
+      ],
+      versioning: 'regex:^android-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)_r(?<build>\\d+)$',
+    },
+  ],
 }


### PR DESCRIPTION
- Refs https://github.com/renovatebot/renovate/discussions/43618#discussioncomment-17075386.
- View the result at https://github.com/Goooler/dalvik-dx/pull/12.